### PR TITLE
Update license to be readable by automated systems

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,9 +1,6 @@
-# License Information
+Copyright 2017 U.S. Federal Government (in countries where recognized) and TrussWorks
 
-Works created by U.S. Federal employees as part of their jobs typically are not eligible for copyright in the United States. In places where the contributions of U.S. Federal employees are not eligible for copyright, this work is in the public domain. In places where it is eligible for copyright, such as some foreign jurisdictions, the remainder of this work is licensed under [the MIT License](https://opensource.org/licenses/MIT), the full text of which is included below.
-
-```text
-Copyright 2018 U.S. Federal Government (in countries where recognized) and TrussWorks
+MIT License
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -22,4 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-```

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 **nom**, the Navy Orders Muncher, ingests CSV files containing Navy Orders and excretes database updates to the move.mil Orders API.
 
+## License Information
+
+Works created by U.S. Federal employees as part of their jobs typically are not eligible for copyright in the United
+States. In places where the contributions of U.S. Federal employees are not eligible for copyright, this work is in
+the public domain. In places where it is eligible for copyright, such as some foreign jurisdictions, the remainder of
+this work is licensed under [the MIT License](https://opensource.org/licenses/MIT), the full text of which is included
+in the [LICENSE.txt](./LICENSE.txt) file in this repository.
+
 ## Usage
 
 `$ nom <csv input file>`


### PR DESCRIPTION
The way the license was set up it can't be readable by godoc.org or pkg.go.dev. So this modifies it to be more standard for machines reading the code.